### PR TITLE
Fix csv/tsv column order

### DIFF
--- a/bionumpy/parser.py
+++ b/bionumpy/parser.py
@@ -85,7 +85,8 @@ class NpBufferStream:
 
     def _remove_header(self):
         if self._has_header:
-            self._file_obj.readline()
+            header = self._file_obj.readline()
+            self._buffer_type.set_fields_from_header(header)
 
 
 class NpBufferedWriter:

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -38,6 +38,7 @@ def test_custom_read():
 
     @npdataclass
     class SampleDC:
+        sequence_aa: str
         sequence: str
 
     for extension, delimiter in {"tsv": "\t", "csv": ","}.items():
@@ -47,6 +48,7 @@ def test_custom_read():
 
         data = bnp_open(path, mode="full", buffer_type=get_bufferclass_for_datatype(SampleDC, delimiter=delimiter), has_header=True)
         assert np.array_equal(data.sequence.to_sequences(), np.array(["AACCTAGGC", "AACCTAGGC"]))
+        assert np.array_equal(data.sequence_aa.to_sequences(), np.array(["ATF", "ATF"]))
 
         os.remove(path)
 


### PR DESCRIPTION
Updated buffer class factory to read the columns into a dict instead of a list, where the field names are sorted by header if header is provided. If not provided, it works the same as before, reading the field names from self.dataclass.